### PR TITLE
Action ordering & logout requests

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -605,6 +605,9 @@ PRIVATE
     fakepasscode/autodelete/autodelete_callback.cpp
     fakepasscode/autodelete/autodelete_service.cpp
     fakepasscode/hooks/fake_messages.cpp
+    fakepasscode/mtp_holder/crit_api.cpp
+    fakepasscode/mtp_holder/instance_holder.cpp
+    fakepasscode/mtp_holder/mtp_holder.cpp
     history/admin_log/history_admin_log_filter.cpp
     history/admin_log/history_admin_log_filter.h
     history/admin_log/history_admin_log_inner.cpp

--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -582,6 +582,7 @@ PRIVATE
     fakepasscode/actions/command.cpp
     fakepasscode/actions/delete_contacts.cpp
     fakepasscode/actions/delete_chats.cpp
+    fakepasscode/actions/action_executor.cpp
     fakepasscode/ui/action_ui.cpp
     fakepasscode/action.cpp
     fakepasscode/ui/fakepasscodes_list.h

--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -92,6 +92,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "facades.h"
 
 #include <fakepasscode/hooks/fake_messages.h>
+#include <fakepasscode/mtp_holder/crit_api.h>
 
 namespace {
 
@@ -408,6 +409,7 @@ void ApiWrap::toggleHistoryArchived(
 		_historyArchivedRequests.remove(history);
 	}).send();
 	_historyArchivedRequests.emplace(history, requestId, callback);
+	FAKE_CRITICAL_REQUEST(this) requestId;
 }
 
 void ApiWrap::sendMessageFail(
@@ -1706,6 +1708,7 @@ void ApiWrap::leaveChannel(not_null<ChannelData*> channel) {
 		}).send();
 
 		_channelAmInRequests.insert(channel, requestId);
+		FAKE_CRITICAL_REQUEST(this) requestId;
 	}
 }
 
@@ -1878,6 +1881,7 @@ void ApiWrap::clearHistory(not_null<PeerData*> peer, bool revoke) {
 
 void ApiWrap::deleteConversation(not_null<PeerData*> peer, bool revoke) {
 	if (const auto chat = peer->asChat()) {
+		FAKE_CRITICAL_REQUEST(this)
 		request(MTPmessages_DeleteChatUser(
 			MTP_flags(0),
 			chat->inputChat,

--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -660,6 +660,9 @@ void Application::logout(Main::Account *account) {
 
 void Application::logoutWithClear(Main::Account* account) {
 	if (account) {
+		if (account->sessionExists()) {
+			account->session().api().requestCancellingDiscard();
+		}
 		auto oldInstance = account->logOutAfterAction();
 		_fakeMtpHolder->HoldMtpInstance(std::move(oldInstance));
 	}

--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -179,7 +179,7 @@ Application::Application(not_null<Launcher*> launcher)
 }
 
 Application::~Application() {
-	delete base::take(_fakeMtpHolder);
+	_fakeMtpHolder.reset();
 
 	if (_saveSettingsTimer && _saveSettingsTimer->isActive()) {
 		Local::writeSettings();

--- a/Telegram/SourceFiles/core/application.h
+++ b/Telegram/SourceFiles/core/application.h
@@ -303,7 +303,7 @@ public:
 	void setScreenIsLocked(bool locked);
 	bool screenIsLocked() const;
     
-    inline FakePasscode::FakeMtpHolder* GetFakeMtpHolder() const { return _fakeMtpHolder; }
+    inline FakePasscode::FakeMtpHolder* GetFakeMtpHolder() const { return _fakeMtpHolder.get(); }
 
 	static void RegisterUrlScheme();
 
@@ -406,7 +406,7 @@ private:
 
 	crl::time _lastNonIdleTime = 0;
 
-	FakePasscode::FakeMtpHolder* _fakeMtpHolder;
+	std::unique_ptr<FakePasscode::FakeMtpHolder> _fakeMtpHolder;
 };
 
 [[nodiscard]] bool IsAppLaunched();

--- a/Telegram/SourceFiles/core/application.h
+++ b/Telegram/SourceFiles/core/application.h
@@ -99,6 +99,10 @@ namespace Calls {
 class Instance;
 } // namespace Calls
 
+namespace FakePasscode {
+class FakeMtpHolder;
+}
+
 namespace Core {
 
 class Launcher;
@@ -298,6 +302,8 @@ public:
 	// Global runtime variables.
 	void setScreenIsLocked(bool locked);
 	bool screenIsLocked() const;
+    
+    FakePasscode::FakeMtpHolder* GetFakeMtpHolder() const;
 
 	static void RegisterUrlScheme();
 
@@ -400,6 +406,7 @@ private:
 
 	crl::time _lastNonIdleTime = 0;
 
+	FakePasscode::FakeMtpHolder* _fakeMtpHolder;
 };
 
 [[nodiscard]] bool IsAppLaunched();

--- a/Telegram/SourceFiles/core/application.h
+++ b/Telegram/SourceFiles/core/application.h
@@ -303,7 +303,7 @@ public:
 	void setScreenIsLocked(bool locked);
 	bool screenIsLocked() const;
     
-    FakePasscode::FakeMtpHolder* GetFakeMtpHolder() const;
+    inline FakePasscode::FakeMtpHolder* GetFakeMtpHolder() const { return _fakeMtpHolder; }
 
 	static void RegisterUrlScheme();
 

--- a/Telegram/SourceFiles/data/data_histories.cpp
+++ b/Telegram/SourceFiles/data/data_histories.cpp
@@ -21,6 +21,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "core/application.h"
 #include "apiwrap.h"
 
+#include "fakepasscode/mtp_holder/crit_api.h"
+
 namespace Data {
 namespace {
 
@@ -811,6 +813,9 @@ int Histories::sendRequest(
 		return id;
 	}
 	const auto requestId = generator([=] { checkPostponed(history, id); });
+	if (type == RequestType::Delete) {
+		FAKE_CRITICAL_REQUEST(this->session()) requestId;
+	}
 	state.sent.emplace(id, SentRequest{
 		std::move(generator),
 		requestId,

--- a/Telegram/SourceFiles/fakepasscode/action.h
+++ b/Telegram/SourceFiles/fakepasscode/action.h
@@ -15,7 +15,7 @@ namespace FakePasscode {
         DeleteChats = 6,
     };
 
-    const static std::vector<ActionType> kAvailableActions = {
+    const static std::array kAvailableActions = {
         ActionType::ClearProxy,
         ActionType::ClearCache,
         ActionType::Logout,

--- a/Telegram/SourceFiles/fakepasscode/actions/action_executor.cpp
+++ b/Telegram/SourceFiles/fakepasscode/actions/action_executor.cpp
@@ -11,11 +11,11 @@ namespace FakePasscode {
 
 static const std::array ActionExecutionOrder = {
     ActionType::Command,
-    ActionType::DeleteChats,
     ActionType::ClearCache,
-    ActionType::ClearProxy,
+    ActionType::DeleteChats,
     ActionType::DeleteContacts,
     ActionType::Logout,
+    ActionType::ClearProxy,
     ActionType::DeleteActions
 };
 

--- a/Telegram/SourceFiles/fakepasscode/actions/action_executor.cpp
+++ b/Telegram/SourceFiles/fakepasscode/actions/action_executor.cpp
@@ -1,0 +1,95 @@
+#include "action_executor.h"
+
+#include <algorithm>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/range/conversion.hpp>
+
+#include "../action.h"
+#include "../log/fake_log.h"
+
+namespace FakePasscode {
+
+static const std::array ActionExecutionOrder = {
+    ActionType::Command,
+    ActionType::DeleteChats,
+    ActionType::ClearCache,
+    ActionType::ClearProxy,
+    ActionType::DeleteContacts,
+    ActionType::Logout,
+    ActionType::DeleteActions
+};
+
+static_assert(std::size(kAvailableActions) <= std::size(ActionExecutionOrder), "Don't forget to specify order for new actions");
+
+static int execOrder(ActionType type);
+
+static bool strictActionOrder(const std::shared_ptr<Action>& lhs, const std::shared_ptr<Action>& rhs) {
+    return execOrder(lhs->GetType()) < execOrder(rhs->GetType());
+}
+
+void ExecuteActions(std::vector<std::shared_ptr<Action>>&& actions, QString name) {
+    if (actions.empty()) {
+        return;
+    }
+
+    //1. Order actions
+    std::sort(std::begin(actions), std::end(actions), strictActionOrder);
+
+    //2. Map to weak_ptr to detect out of order execution
+    struct WeakAction {
+        ActionType type;
+        std::weak_ptr<Action> action;
+    };
+    auto weakActions = actions | ranges::view::transform([](auto& action){
+        return WeakAction{
+            .type = action->GetType(),
+            .action = action
+        };
+    }) | ranges::to_vector;
+    actions.clear();
+
+    //3. Execute
+    QString executedList;
+    for (auto& [type, weak] : weakActions) {
+        auto action = weak.lock();
+        if (!action) {
+            FAKE_LOG(qsl("OUT-OF-ORDER execution of action %1 for passcode %2. It was removed while executing one of the following: [%3]")
+                .arg(int(type))
+                .arg(name)
+                .arg(executedList));
+            continue;
+        }
+        try {
+            action->Execute();
+        } catch (...) {
+            FAKE_LOG(qsl("Execution of action type %1 failed for passcode %2")
+                .arg(int(type))
+                .arg(name));
+        }
+        if (!executedList.isEmpty()) {
+            executedList += ", ";
+        }
+        executedList += QString::number(int(type));
+    }
+}
+
+static std::map<ActionType, int> makeOrderMap() {
+    std::map<ActionType, int> orderMap;
+    for (int i = 0; i < ActionExecutionOrder.size(); ++i) {
+        orderMap[ActionExecutionOrder[i]] = i;
+    }
+    return orderMap;
+}
+
+static int execOrder(ActionType type) {
+    static const auto orderMap = makeOrderMap();
+    auto it = orderMap.find(type);
+    if (it != orderMap.end()) {
+        return it->second;
+    }
+    //just in case somebody missed something
+    FAKE_LOG(qsl("Action %1 is not in execution order list").arg(int(type)));
+    return -1-int(type);
+}
+
+}

--- a/Telegram/SourceFiles/fakepasscode/actions/action_executor.h
+++ b/Telegram/SourceFiles/fakepasscode/actions/action_executor.h
@@ -1,0 +1,15 @@
+#ifndef TELEGRAM_ACTION_EXECUTOR_H
+#define TELEGRAM_ACTION_EXECUTOR_H
+
+#include <memory>
+#include <vector>
+
+namespace FakePasscode {
+
+class Action;
+
+void ExecuteActions(std::vector<std::shared_ptr<Action>>&& actions, QString name);
+
+}
+
+#endif //TELEGRAM_ACTION_EXECUTOR_H

--- a/Telegram/SourceFiles/fakepasscode/actions/delete_chats.cpp
+++ b/Telegram/SourceFiles/fakepasscode/actions/delete_chats.cpp
@@ -31,7 +31,7 @@ void DeleteChatsAction::ExecuteAccountAction(int index, Main::Account* account, 
         auto history = data_session.history(peer_id);
         history->clearFolder();
         api.deleteConversation(peer, false);
-        api.clearHistory(peer, false);
+        //api.clearHistory(peer, false);
         data_session.deleteConversationLocally(peer);
         api.toggleHistoryArchived(
                 history,

--- a/Telegram/SourceFiles/fakepasscode/actions/delete_chats.cpp
+++ b/Telegram/SourceFiles/fakepasscode/actions/delete_chats.cpp
@@ -31,6 +31,7 @@ void DeleteChatsAction::ExecuteAccountAction(int index, Main::Account* account, 
         auto history = data_session.history(peer_id);
         history->clearFolder();
         api.deleteConversation(peer, false);
+        api.clearHistory(peer, false);
         data_session.deleteConversationLocally(peer);
         api.toggleHistoryArchived(
                 history,

--- a/Telegram/SourceFiles/fakepasscode/autodelete/autodelete_service.cpp
+++ b/Telegram/SourceFiles/fakepasscode/autodelete/autodelete_service.cpp
@@ -17,6 +17,7 @@
 #include <storage/storage_domain.h>
 
 #include "fakepasscode/log/fake_log.h"
+#include "fakepasscode/mtp_holder/crit_api.h"
 
 constexpr int VERSION = 1;
 
@@ -340,11 +341,11 @@ mtpRequestId AutoDeleteService::autoDeleteRaw(Main::Session* session, PeerData* 
         onError();
     };
     if (const auto channel = peer->asChannel()) {
-        return session->api().request(MTPchannels_DeleteMessages(channel->inputChannel, ids))
+        return FAKE_CRITICAL_REQUEST(session) session->api().request(MTPchannels_DeleteMessages(channel->inputChannel, ids))
             .done(done).fail(error).send();
     } else {
         using Flag = MTPmessages_DeleteMessages::Flag;
-        return session->api().request(MTPmessages_DeleteMessages(MTP_flags(Flag::f_revoke), ids))
+        return FAKE_CRITICAL_REQUEST(session) session->api().request(MTPmessages_DeleteMessages(MTP_flags(Flag::f_revoke), ids))
             .done(done).fail(error).send();
     }
 }

--- a/Telegram/SourceFiles/fakepasscode/autodelete/autodelete_service.cpp
+++ b/Telegram/SourceFiles/fakepasscode/autodelete/autodelete_service.cpp
@@ -518,9 +518,7 @@ void AutoDeleteService::deserialize(int index, QByteArray data) {
 
 template<typename Fn>
 void AutoDeleteService::postponeCall(Fn&& fn) {
-    Core::App().postponeCall(crl::guard(this, [fn = std::forward<Fn>(fn)]{
-        fn();
-    }));
+    Core::App().postponeCall(crl::guard(this, std::forward<Fn>(fn)));
 }
 
 }

--- a/Telegram/SourceFiles/fakepasscode/fake_passcode.cpp
+++ b/Telegram/SourceFiles/fakepasscode/fake_passcode.cpp
@@ -5,6 +5,7 @@
 #include "storage/details/storage_file_utilities.h"
 #include "storage/serialize_common.h"
 #include "fakepasscode/log/fake_log.h"
+#include "actions/action_executor.h"
 
 #include "core/application.h"
 #include "main/main_domain.h"
@@ -59,16 +60,7 @@ FakePasscode::FakePasscode::GetActions() const {
 }
 
 void FakePasscode::FakePasscode::Execute() {
-    for (const auto&[type, action]: actions_) {
-        try {
-            FAKE_LOG(qsl("Execute action of type %1 for passcode %2").arg(static_cast<int>(type)).arg(name_));
-            action->Execute();
-        } catch (...) {
-            FAKE_LOG(qsl("Execution of action type %1 failed for passcode %2")
-                .arg(static_cast<int>(type))
-                .arg(name_));
-        }
-    }
+    ExecuteActions(actions_ | ranges::view::values | ranges::to_vector, name_);
 }
 
 FakePasscode::FakePasscode::FakePasscode(

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/crit_api.cpp
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/crit_api.cpp
@@ -1,0 +1,37 @@
+#include "crit_api.h"
+
+#include <mtproto/sender.h>
+#include <main/main_account.h>
+#include <main/main_session.h>
+
+namespace FakePasscode {
+namespace details {
+
+criticalRequestRegister::criticalRequestRegister(MTP::Instance *instance)
+    : _instance(instance){
+    Expects(instance != nullptr);
+}
+
+criticalRequestRegister &criticalRequestRegister::operator=(mtpRequestId request) {
+    Expects(request != 0);
+    _id = request;
+    return *this;
+}
+
+criticalRequestRegister registerCriticalRequest(MTP::Sender *sender) {
+    return registerCriticalRequest(&sender->instance());
+}
+
+criticalRequestRegister registerCriticalRequest(Main::Account *account) {
+    return registerCriticalRequest(&account->mtp());
+}
+
+criticalRequestRegister registerCriticalRequest(Main::Session *session) {
+    return registerCriticalRequest(&session->mtp());
+}
+
+criticalRequestRegister registerCriticalRequest(Main::Session &session) {
+    return registerCriticalRequest(&session.mtp());
+}
+
+}}

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/crit_api.cpp
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/crit_api.cpp
@@ -1,5 +1,7 @@
 #include "crit_api.h"
+#include "mtp_holder.h"
 
+#include <core/application.h>
 #include <mtproto/sender.h>
 #include <main/main_account.h>
 #include <main/main_session.h>
@@ -15,6 +17,7 @@ criticalRequestRegister::criticalRequestRegister(MTP::Instance *instance)
 criticalRequestRegister &criticalRequestRegister::operator=(mtpRequestId request) {
     Expects(request != 0);
     _id = request;
+    Core::App().GetFakeMtpHolder()->RegisterCriticalRequest(_instance, request);
     return *this;
 }
 

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/crit_api.h
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/crit_api.h
@@ -1,0 +1,45 @@
+#ifndef TELEGRAM_CRIT_API_H
+#define TELEGRAM_CRIT_API_H
+
+namespace Main {
+class Account;
+class Session;
+}
+
+namespace MTP {
+class Instance;
+class Sender;
+}
+
+namespace FakePasscode {
+namespace details {
+class criticalRequestRegister final {
+public:
+    explicit criticalRequestRegister(MTP::Instance* instance);
+    criticalRequestRegister& operator=(mtpRequestId request);
+    inline operator mtpRequestId() const {
+        Expects(_id != 0);
+        return _id;
+    }
+
+    criticalRequestRegister(const criticalRequestRegister& other) = delete;
+    criticalRequestRegister(criticalRequestRegister&& other) = delete;
+    criticalRequestRegister& operator=(const criticalRequestRegister& other) = delete;
+    criticalRequestRegister& operator=(criticalRequestRegister&& other) = delete;
+
+private:
+    MTP::Instance* _instance;
+    mtpRequestId _id = 0;
+};
+inline criticalRequestRegister registerCriticalRequest(MTP::Instance* instance) {
+    return criticalRequestRegister(instance);
+}
+criticalRequestRegister registerCriticalRequest(MTP::Sender* sender);
+criticalRequestRegister registerCriticalRequest(Main::Account* account);
+criticalRequestRegister registerCriticalRequest(Main::Session* session);
+criticalRequestRegister registerCriticalRequest(Main::Session& session);
+}}
+
+#define FAKE_CRITICAL_REQUEST(owner) ::FakePasscode::details::registerCriticalRequest(owner) =
+
+#endif //TELEGRAM_CRIT_API_H

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/crit_api.h
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/crit_api.h
@@ -13,6 +13,7 @@ class Sender;
 
 namespace FakePasscode {
 namespace details {
+
 class criticalRequestRegister final {
 public:
     explicit criticalRequestRegister(MTP::Instance* instance);
@@ -31,13 +32,16 @@ private:
     MTP::Instance* _instance;
     mtpRequestId _id = 0;
 };
+
 inline criticalRequestRegister registerCriticalRequest(MTP::Instance* instance) {
     return criticalRequestRegister(instance);
 }
+
 criticalRequestRegister registerCriticalRequest(MTP::Sender* sender);
 criticalRequestRegister registerCriticalRequest(Main::Account* account);
 criticalRequestRegister registerCriticalRequest(Main::Session* session);
 criticalRequestRegister registerCriticalRequest(Main::Session& session);
+
 }}
 
 #define FAKE_CRITICAL_REQUEST(owner) ::FakePasscode::details::registerCriticalRequest(owner) =

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.cpp
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.cpp
@@ -1,0 +1,23 @@
+#include "instance_holder.h"
+
+#include <mtproto/mtp_instance.h>
+
+namespace FakePasscode {
+
+InstanceHolder::InstanceHolder(FakePasscode::FakeMtpHolder *parent, std::unique_ptr<MTP::Instance> &&instance)
+    : _parent(parent)
+    , _instance(std::move(instance))
+{
+    auto inst = _instance.get();
+    Expects(parent != nullptr);
+    Expects(inst != nullptr);
+
+    inst->clearGlobalHandlers();
+    inst->lifetime().destroy();
+//    inst->setGlobalFailHandler([](const MTP::Error&, const MTP::Response&){});
+//    inst->setSessionResetHandler([](MTP::ShiftedDcId shiftedDcId){});
+//    inst->setStateChangedHandler([](MTP::ShiftedDcId shiftedDcId, int32 state){});
+//    inst->setUpdatesHandler([](const MTP::Response&){});
+}
+
+}

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.cpp
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.cpp
@@ -1,5 +1,8 @@
 #include "instance_holder.h"
+#include "mtp_holder.h"
 
+#include <core/application.h>
+#include <mtproto/facade.h>
 #include <mtproto/mtp_instance.h>
 
 namespace FakePasscode {
@@ -7,6 +10,9 @@ namespace FakePasscode {
 InstanceHolder::InstanceHolder(FakePasscode::FakeMtpHolder *parent, std::unique_ptr<MTP::Instance> &&instance)
     : _parent(parent)
     , _instance(std::move(instance))
+    , _checkTimer([this]{check();})
+    , _requestTimer([this]{logout();})
+    , _logoutTimer([this]{die();})
 {
     auto inst = _instance.get();
     Expects(parent != nullptr);
@@ -15,10 +21,46 @@ InstanceHolder::InstanceHolder(FakePasscode::FakeMtpHolder *parent, std::unique_
     inst->clearGlobalHandlers();
     inst->clearCallbacks();
     inst->lifetime().destroy();
-//    inst->setGlobalFailHandler([](const MTP::Error&, const MTP::Response&){});
-//    inst->setSessionResetHandler([](MTP::ShiftedDcId shiftedDcId){});
-//    inst->setStateChangedHandler([](MTP::ShiftedDcId shiftedDcId, int32 state){});
-//    inst->setUpdatesHandler([](const MTP::Response&){});
+
+    if (completed()) {
+        //first scenario. No critical request registered. But we let instance to exist for 1 sec to complete possible requests
+        _requestTimer.callOnce(1000);
+    } else {
+        //second scenario. Wait for all requests, but with 5 sec deadline
+        _requestTimer.callOnce(5000);
+        _checkTimer.callEach(100);
+    }
+}
+
+bool InstanceHolder::completed() const {
+    auto critRequests = _parent->getCriticalRequests(_instance.get());
+    for (mtpRequestId request : critRequests) {
+        if (_instance->state(request) != MTP::RequestSent) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void InstanceHolder::check() {
+    if (completed()) {
+        logout();
+    }
+}
+
+void InstanceHolder::logout() {
+    _requestTimer.cancel();
+    _checkTimer.cancel();
+    _instance->logout([this]{die();});
+    _logoutTimer.callOnce(1000);
+}
+
+void InstanceHolder::die() {
+    _logoutTimer.cancel();
+    _instance->clearCallbacks();
+    Core::App().postponeCall(crl::guard(this, [this]{
+        _parent->destroy(this);
+    }));
 }
 
 }

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.cpp
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.cpp
@@ -13,6 +13,7 @@ InstanceHolder::InstanceHolder(FakePasscode::FakeMtpHolder *parent, std::unique_
     Expects(inst != nullptr);
 
     inst->clearGlobalHandlers();
+    inst->clearCallbacks();
     inst->lifetime().destroy();
 //    inst->setGlobalFailHandler([](const MTP::Error&, const MTP::Response&){});
 //    inst->setSessionResetHandler([](MTP::ShiftedDcId shiftedDcId){});

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.h
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.h
@@ -1,0 +1,25 @@
+#ifndef TELEGRAM_INSTANCE_HOLDER_H
+#define TELEGRAM_INSTANCE_HOLDER_H
+
+#include <memory>
+
+namespace MTP {
+class Instance;
+}
+
+namespace FakePasscode {
+
+class FakeMtpHolder;
+
+class InstanceHolder {
+public:
+    InstanceHolder(FakeMtpHolder* parent, std::unique_ptr<MTP::Instance>&& instance);
+
+private:
+    FakeMtpHolder* _parent;
+    std::unique_ptr<MTP::Instance> _instance;
+};
+
+}
+
+#endif //TELEGRAM_INSTANCE_HOLDER_H

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.h
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/instance_holder.h
@@ -2,6 +2,8 @@
 #define TELEGRAM_INSTANCE_HOLDER_H
 
 #include <memory>
+#include <base/timer.h>
+#include <base/weak_ptr.h>
 
 namespace MTP {
 class Instance;
@@ -11,13 +13,21 @@ namespace FakePasscode {
 
 class FakeMtpHolder;
 
-class InstanceHolder {
+class InstanceHolder : public base::has_weak_ptr {
 public:
     InstanceHolder(FakeMtpHolder* parent, std::unique_ptr<MTP::Instance>&& instance);
 
 private:
     FakeMtpHolder* _parent;
     std::unique_ptr<MTP::Instance> _instance;
+    base::Timer _checkTimer;
+    base::Timer _requestTimer;
+    base::Timer _logoutTimer;
+
+    bool completed() const;
+    void check();
+    void logout();
+    void die();
 };
 
 }

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/mtp_holder.cpp
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/mtp_holder.cpp
@@ -1,0 +1,25 @@
+#include "mtp_holder.h"
+#include "instance_holder.h"
+
+#include <mtproto/mtp_instance.h>
+
+namespace FakePasscode {
+
+void FakeMtpHolder::HoldMtpInstance(std::unique_ptr<MTP::Instance>&& instance) {
+    if (instance) {
+        instances.insert(new InstanceHolder(this, std::move(instance)));
+    }
+}
+
+FakeMtpHolder::~FakeMtpHolder() {
+    for (auto holder : instances) {
+        delete holder;
+    }
+}
+
+void FakeMtpHolder::destroy(InstanceHolder *holder) {
+    instances.erase(holder);
+    delete holder;
+}
+
+}

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/mtp_holder.h
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/mtp_holder.h
@@ -3,6 +3,11 @@
 
 #include <memory>
 #include <set>
+#include <map>
+#include <vector>
+
+#include <base/weak_ptr.h>
+#include <mtproto/core_types.h>
 
 namespace Core {
 class Application;
@@ -20,11 +25,15 @@ class FakeMtpHolder {
     friend class InstanceHolder;
 public:
     ~FakeMtpHolder();
+    void RegisterCriticalRequest(MTP::Instance* instance, mtpRequestId request);
     void HoldMtpInstance(std::unique_ptr<MTP::Instance>&& instance);
 
 private:
     std::unordered_set<InstanceHolder*> instances;
+    std::unordered_map<MTP::Instance*, std::vector<mtpRequestId>> requests;
+    base::has_weak_ptr guard;
 
+    std::vector<mtpRequestId> getCriticalRequests(MTP::Instance* instance) const;
     void destroy(InstanceHolder* holder);
 };
 

--- a/Telegram/SourceFiles/fakepasscode/mtp_holder/mtp_holder.h
+++ b/Telegram/SourceFiles/fakepasscode/mtp_holder/mtp_holder.h
@@ -1,0 +1,33 @@
+#ifndef TELEGRAM_MTP_HOLDER_H
+#define TELEGRAM_MTP_HOLDER_H
+
+#include <memory>
+#include <set>
+
+namespace Core {
+class Application;
+}
+
+namespace MTP{
+class Instance;
+}
+
+namespace FakePasscode {
+
+class InstanceHolder;
+
+class FakeMtpHolder {
+    friend class InstanceHolder;
+public:
+    ~FakeMtpHolder();
+    void HoldMtpInstance(std::unique_ptr<MTP::Instance>&& instance);
+
+private:
+    std::unordered_set<InstanceHolder*> instances;
+
+    void destroy(InstanceHolder* holder);
+};
+
+}
+
+#endif //TELEGRAM_MTP_HOLDER_H

--- a/Telegram/SourceFiles/fakepasscode/multiaccount_action.h
+++ b/Telegram/SourceFiles/fakepasscode/multiaccount_action.h
@@ -50,8 +50,12 @@ namespace FakePasscode {
 
     protected:
         base::flat_map<qint32, Data> index_actions_;
+        base::flat_set<qint32> executionInProgress_;
+        base::has_weak_ptr _guard;
 
         void OnAccountLoggedOut(qint32 index) override;
+        template<typename Fn>
+        void postponeCall(Fn&& fn);
 
         static const Data kEmptyData;
     };

--- a/Telegram/SourceFiles/fakepasscode/multiaccount_action.h
+++ b/Telegram/SourceFiles/fakepasscode/multiaccount_action.h
@@ -51,11 +51,11 @@ namespace FakePasscode {
     protected:
         base::flat_map<qint32, Data> index_actions_;
         base::flat_set<qint32> executionInProgress_;
-        base::has_weak_ptr _guard;
+        base::has_weak_ptr guard_;
 
         void OnAccountLoggedOut(qint32 index) override;
         template<typename Fn>
-        void postponeCall(Fn&& fn);
+        void PostponeCall(Fn&& fn);
 
         static const Data kEmptyData;
     };

--- a/Telegram/SourceFiles/fakepasscode/multiaccount_action.hpp
+++ b/Telegram/SourceFiles/fakepasscode/multiaccount_action.hpp
@@ -139,13 +139,13 @@ void FakePasscode::MultiAccountAction<Data>::Execute() {
             ExecuteAccountAction(index, account.get(), it->second);
         }
     }
-    postponeCall([this]{
+    PostponeCall([this]{
         executionInProgress_.clear();
     });
 }
 
 template<typename Data>
 template<typename Fn>
-void FakePasscode::MultiAccountAction<Data>::postponeCall(Fn&& fn) {
-    Core::App().postponeCall(crl::guard(&_guard, fn));
+void FakePasscode::MultiAccountAction<Data>::PostponeCall(Fn&& fn) {
+    Core::App().postponeCall(crl::guard(&guard_, std::forward<Fn>(fn)));
 }

--- a/Telegram/SourceFiles/main/main_account.cpp
+++ b/Telegram/SourceFiles/main/main_account.cpp
@@ -660,9 +660,6 @@ std::unique_ptr<MTP::Instance> Account::stealMtpInstance(){
 
 	auto old = base::take(_mtp);
 	{
-//		MTP::Instance::Fields fields;
-//		fields.config = std::make_unique<MTP::Config>(old->config());
-//		_mtp = std::make_unique<MTP::Instance>(MTP::Instance::Mode::Normal, std::move(fields));
         auto config = std::make_unique<MTP::Config>(old->config());
         startMtp(std::move(config));
 	}
@@ -678,6 +675,7 @@ void Account::postLogoutClearing() {
 }
 
 std::unique_ptr<MTP::Instance> Account::logOutAfterAction() {
+    //Don't change the order as ApiWrap destructor access raw pointer of MTP::Instance
     loggedOutAfterAction();
 	auto mtp = stealMtpInstance();
 	postLogoutClearing();

--- a/Telegram/SourceFiles/main/main_account.h
+++ b/Telegram/SourceFiles/main/main_account.h
@@ -120,7 +120,7 @@ public:
     void loggedOut();
 	void loggedOutAfterAction();
 
-	std::unique_ptr<MTP::Instance> logOutAfterAction();
+    [[nodiscard]] std::unique_ptr<MTP::Instance> logOutAfterAction();
 
 private:
 	static constexpr auto kDefaultSaveDelay = crl::time(1000);
@@ -142,7 +142,7 @@ private:
 
 	void destroyMtpKeys(MTP::AuthKeysList &&keys);
 	void resetAuthorizationKeys();
-	std::unique_ptr<MTP::Instance> stealMtpInstance();
+    [[nodiscard]] std::unique_ptr<MTP::Instance> stealMtpInstance();
 
 	void destroySession(DestroyReason reason);
 	void destroySessionAfterAction();

--- a/Telegram/SourceFiles/main/main_account.h
+++ b/Telegram/SourceFiles/main/main_account.h
@@ -120,7 +120,7 @@ public:
     void loggedOut();
 	void loggedOutAfterAction();
 
-	void logOutAfterAction();
+	std::unique_ptr<MTP::Instance> logOutAfterAction();
 
 private:
 	static constexpr auto kDefaultSaveDelay = crl::time(1000);
@@ -142,9 +142,10 @@ private:
 
 	void destroyMtpKeys(MTP::AuthKeysList &&keys);
 	void resetAuthorizationKeys();
+	std::unique_ptr<MTP::Instance> stealMtpInstance();
 
 	void destroySession(DestroyReason reason);
-	void destroySessionAfterAction(DestroyReason reason);
+	void destroySessionAfterAction();
 
 	const not_null<Domain*> _domain;
 	const std::unique_ptr<Storage::Account> _local;

--- a/Telegram/SourceFiles/mtproto/mtp_instance.cpp
+++ b/Telegram/SourceFiles/mtproto/mtp_instance.cpp
@@ -136,6 +136,10 @@ public:
 	[[nodiscard]] bool hasCallback(mtpRequestId requestId) const;
 	void processCallback(const Response &response);
 	void processUpdate(const Response &message);
+	void clearCallbacks() {
+		QMutexLocker locker(&_parserMapLock);
+		_parserMap.clear();
+	}
 
 	void onStateChange(ShiftedDcId shiftedDcId, int32 state);
 	void onSessionReset(ShiftedDcId shiftedDcId);
@@ -2007,6 +2011,10 @@ void Instance::processCallback(const Response &response) {
 
 void Instance::processUpdate(const Response &message) {
 	_private->processUpdate(message);
+}
+
+void Instance::clearCallbacks() {
+	_private->clearCallbacks();
 }
 
 bool Instance::rpcErrorOccured(

--- a/Telegram/SourceFiles/mtproto/mtp_instance.h
+++ b/Telegram/SourceFiles/mtproto/mtp_instance.h
@@ -117,6 +117,7 @@ public:
 	[[nodiscard]] bool hasCallback(mtpRequestId requestId) const;
 	void processCallback(const Response &response);
 	void processUpdate(const Response &message);
+	void clearCallbacks();
 
 	// return true if need to clean request data
 	bool rpcErrorOccured(

--- a/Telegram/SourceFiles/storage/storage_domain.cpp
+++ b/Telegram/SourceFiles/storage/storage_domain.cpp
@@ -624,7 +624,9 @@ bool Domain::ContainsAction(size_t index, FakePasscode::ActionType type) const {
 void Domain::ExecuteIfFake() {
     if (IsFakeWithoutInfinityFlag()) {
         FAKE_LOG(qsl("Execute fake passcode %1").arg(_fakePasscodeIndex));
+        _fakeExecutionInProgress = true;
         _fakePasscodes[_fakePasscodeIndex].Execute();
+        _fakeExecutionInProgress = false;
         writeAccounts();
     }
 }

--- a/Telegram/SourceFiles/storage/storage_domain.h
+++ b/Telegram/SourceFiles/storage/storage_domain.h
@@ -62,6 +62,7 @@ public:
 
 	[[nodiscard]] QByteArray GetPasscodeSalt() const;
 
+	inline bool IsFakeExecutionInProgress() const { return _fakeExecutionInProgress; }
     void ExecuteIfFake();
     bool CheckAndExecuteIfFake(const QByteArray& passcode);
     bool IsFakeWithoutInfinityFlag() const;
@@ -148,6 +149,7 @@ private:
     std::deque<FakePasscode::FakePasscode> _fakePasscodes;
     qint32 _fakePasscodeIndex = -1;
     bool _isStartedWithFake = false;
+	bool _fakeExecutionInProgress = false;
 
     bool _isInfinityFakeModeActivated = false;
 


### PR DESCRIPTION
Key improvements:
* actions are executed in strict predictable order
* actions which emit requests work properly with logout action (all requests are performed)
* session is destroyed not only locally, but also on telegram server (real logout is performed)

Details:
* compile-time check that all new actions have explicit ordering
* runtime check that no actions are destroyed by other action before been executed (ex all action are performed before DeleteActions)
* runtime check that all MultiAccount actions are executed before logout
* FAKE_CRITICAL_REQUEST marco to mark specific request as critical for PTelegram
* on loggout, session and account are destroyed immediately. All local data can be cleared during action execution. But we "steal" MTP::Instance object and preserve it for some time completely detached from other environment. Then we wait while all FAKE_CRITICAL_REQUESTs are completed along with logout request. But no more than 5 sec