### PR TITLE
Disable sending auto delete messages to channels

### DIFF
--- a/Telegram/SourceFiles/menu/menu_send.cpp
+++ b/Telegram/SourceFiles/menu/menu_send.cpp
@@ -54,7 +54,7 @@ FillMenuResult FillSendMenu(
 		Fn<void()> schedule,
 		Fn<void()> autoDelete) {
 	if (FakePasscode::DisableAutoDeleteInContextMenu()) {
-		autoDelete = nullptr;
+		autoDelete = NoAutoDeleteCallback();
 	}
 	if (!silent && !schedule && !autoDelete) {
 		return FillMenuResult::None;


### PR DESCRIPTION
Autodeletable messages works not as expected on channels, so we need to investigate ability to use them in channels. Disable for now.