### PR TITLE
Fix Linux actions/builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,11 +30,6 @@ on:
         required: false
         type: string
         default: ''
-      dockerImage:
-        description: 'Docker image to use'
-        required: false
-        type: string
-        default: 'ghcr.io/wrwrabbit/centos_env'
 
 jobs:
 
@@ -43,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container:
-      image: ${{ github.event.inputs.dockerImage }}
+      image: ghcr.io/wrwrabbit/centos_env
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -93,10 +88,6 @@ jobs:
 
           ARTIFACT_PREFIX=""
           
-          if [ "${{ github.event.inputs.dockerImage }}" != 'ghcr.io/wrwrabbit/centos_env' ]; then
-            echo Dev build: using custom docker image: ${{ github.event.inputs.dockerImage }}
-            ARTIFACT_PREFIX="dev"
-          fi
           if [ "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]; then
             echo Dev build: using non master branch: ${{ github.ref_name }}
             ARTIFACT_PREFIX="dev"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container:
-      image: ghcr.io/wrwrabbit/centos_env
+      image: ghcr.io/${{ github.repository }}/centos_env
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,6 +173,7 @@ parts:
 
   patches:
     source: https://github.com/desktop-app/patches.git
+    source-commit: 2c464cfbd9fa3c1d88335cf9462c8ef96542f87c
     source-depth: 1
     plugin: dump
     override-pull: |


### PR DESCRIPTION
linux.yml: 

github.input is not available on pull_request triggered actions, so this is not a proper way to have custom docker image

snapcraft.yml

in upstream snapcraft is checking out latest version of desktop/patches.git repo. Which make snap build volatile.
Fixed the version of patches that are intented to be used in 4.10.1