### PR TITLE
create per architecture release zips

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -126,8 +126,7 @@ jobs:
           fi
           echo "TDESKTOP_BUILD_DEFINE=$DEFINE" >> $GITHUB_ENV
 
-          # Use single PTelegram_Win
-          #echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
 
           API="-D TDESKTOP_API_TEST=ON"
           if [ $GITHUB_REF == 'refs/heads/nightly' ]; then
@@ -163,13 +162,13 @@ jobs:
       - name: Move and hash artifact.
         if: env.UPLOAD_ARTIFACT == 'true'
         run: |
-          mkdir artifact
-          move %TBUILD%\tdesktop\out\Release\Telegram.exe artifact/Telegram_${{ matrix.arch }}.exe
-          certutil -hashfile artifact/Telegram_${{ matrix.arch }}.exe SHA256 | find /i /v "SHA256" | find /i /v "CertUtil" > artifact/Telegram_${{ matrix.arch }}_sha256.txt
+          mkdir artifact_${{ matrix.arch }}
+          move %TBUILD%\tdesktop\out\Release\Telegram.exe artifact_${{ matrix.arch }}/Telegram_${{ matrix.arch }}.exe
+          certutil -hashfile artifact_${{ matrix.arch }}/Telegram_${{ matrix.arch }}.exe SHA256 | find /i /v "SHA256" | find /i /v "CertUtil" > artifact_${{ matrix.arch }}/Telegram_${{ matrix.arch }}_sha256.txt
 
       - uses: actions/upload-artifact@master
         name: Upload artifact.
         if: env.UPLOAD_ARTIFACT == 'true'
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: artifact\
+          path: artifact_${{ matrix.arch }}\


### PR DESCRIPTION
create per architecture release zips

recent changes to upload-artifacts (v4) action forbid uploading artifacts with the same name.
windows artifact was uploading same artifact twice.